### PR TITLE
Add Jsonnet Ambari demo + modifications to Jsonnet configuration module

### DIFF
--- a/apps/hortonworks/hdp2/centos6/ambari.jsonnet
+++ b/apps/hortonworks/hdp2/centos6/ambari.jsonnet
@@ -1,0 +1,66 @@
+// Copyright 2014 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+// Ambari server + agent deployment.
+
+local gce = import "../../../../gce.jsonnet";
+
+{
+    zone:: "us-central1-b",
+    serverMachineTypeName:: "n1-standard-1",
+    agentMachineTypeName:: "n1-standard-4",
+    numAgents:: 5,
+
+    server:: gce.Instance { 
+        name: "ambari-server-0",
+        machineTypeName:: $.serverMachineTypeName,
+        zoneName:: $.zone,
+        metadataMap:: {
+            "startup-script": gce.StripComments(std.join("\n", [
+                importstr "scripts/init/ambari-repo-init.sh",
+                importstr "scripts/init/ambari-server-install.sh",
+                importstr "scripts/init/ambari-server-setup.sh",
+                importstr "scripts/init/ambari-server-start.sh",
+            ])), 
+        },
+        disks: [
+            gce.BootDisk {
+                owner:: $.server,
+                image:: gce.MakeUrl(["centos-cloud", "global", "images", "centos-6-v20140415"])
+            }
+        ],
+    },
+
+    agent(i):: gce.Instance {
+        local agent = self,
+        name: "ambari-agent-%d" % [i],
+        machineTypeName:: $.agentMachineTypeName,
+        zoneName:: $.zone,
+        metadataMap:: {
+            "ambari-server": "ambari-server-0",
+            "startup-script": gce.StripComments(std.join("\n",[
+                importstr "../../../common/fdisk.sh",
+                importstr "scripts/init/ambari-repo-init.sh",
+                importstr "scripts/init/ambari-agent-install.sh",
+                importstr "scripts/init/ambari-agent-setup.sh",
+                importstr "scripts/init/ambari-agent-start.sh",
+            ])),
+        },
+        disks: [ $.server.disks[0] + { owner:: agent, sizeGb:: 500, } ],
+    },
+
+    resources: [$.server] + [ $.agent(i) for i in std.range(0, $.numAgents - 1) ]
+}

--- a/apps/hortonworks/hdp2/centos6/ambari_small.jsonnet
+++ b/apps/hortonworks/hdp2/centos6/ambari_small.jsonnet
@@ -1,0 +1,26 @@
+// Copyright 2014 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+// Ambari variant with fewer, smaller nodes.
+
+import "ambari.jsonnet" + {
+    serverMachineTypeName:: "f1-micro",
+    agentMachineTypeName:: "n1-standard-1",
+    numAgents:: 2,
+    agent(i):: super.agent(i) + {
+        disks: [ super.disks[0] + { sizeGb:: 100, } ],
+    }
+}

--- a/config_jsonnet.py
+++ b/config_jsonnet.py
@@ -21,12 +21,6 @@
 import json
 import sys
 
-# Jsonnet interpreter
-try:
-  import _jsonnet
-except:
-  _jsonnet = None
-
 # Local imports
 import common
 
@@ -47,10 +41,15 @@ class ConfigExpander(object):
       self.__kwargs[key] = value
 
   def ExpandFile(self, file_name):
-    if _jsonnet is None:
-      raise JsonnetNotFoundError('Module "_jsonnet" missing; Jsonnet support unavailable.')
-    json_str = _jsonnet.evaluate_file(file_name)
-    return json.loads(json_str)
+    # Jsonnet interpreter, import only if needed to avoid dependency.
+    try:
+      import _jsonnet
+    except:
+      raise JsonnetNotFoundError('Module "_jsonnet" missing;  Is _jsonnet.so in your $PYTHONPATH?')
+    project = self.__kwargs['project']
+    json_str = _jsonnet.evaluate_file(file_name, env={'GCP_PROJECT': project})
+    json_data = json.loads(json_str)
+    return json_data['resources']
 
 def main(argv):
   if len(argv) < 2:

--- a/gce.jsonnet
+++ b/gce.jsonnet
@@ -1,0 +1,92 @@
+// Copyright 2014 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+// GCE utility classes
+
+{
+    local proj = std.env("GCP_PROJECT"),
+    local gce = self,
+
+    StripComments(str)::
+        local lines = std.split(str, "\n");
+        local keep_line(line) =
+            local aux(line, i) =
+                local c = line[i];
+                if i >= std.length(line) then
+                    true
+                else if c == " " || c == "\t" then
+                    local i2 = i+1;
+                    if std.force(i2) then
+                        aux(line, i2)
+                    else
+                        null
+                else 
+                    c != "#" || (i + 1 < std.length(line) && line[i + 1] == "!");
+            aux(line, 0);
+        local no_comments = std.filter(keep_line, lines);
+        std.join("\n", no_comments),
+
+    MakeUrl(parts)::
+        local base = "https://www.googleapis.com/compute/v1/projects";
+        std.join("/", [base] + parts),
+
+    Instance:: {
+        local instance = self,
+        project:: proj,
+        zone: gce.MakeUrl([proj, "zones", self.zoneName]),
+        machineType: "%s/machineTypes/%s" % [self.zone, self.machineTypeName],
+        metadata: {
+            items:
+                local m = instance.metadataMap;
+                [ { key: k, value: m[k] } for k in std.objectFields(m) ]
+        },
+        networkInterfaces: [
+            {
+                accessConfigs: [
+                    {
+                        name: "External NAT",
+                        type: "ONE_TO_ONE_NAT"
+                    }
+                ],
+                network: gce.MakeUrl([proj, "global", "networks", "default"]),
+            }
+        ],
+        serviceAccounts: [
+            {
+                email: "default",
+                scopes: [
+                    "https://www.googleapis.com/auth/devstorage.full_control",
+                    "https://www.googleapis.com/auth/compute"
+                ]
+            }
+        ],
+    },
+
+    BootDisk:: {
+        local disk = self,
+        autoDelete: true,
+        boot: true,
+        deviceName: "disk-0",
+        sizeGb:: 10,
+        initializeParams: {
+            diskName: "%s-disk-0" % [disk.owner.name],
+            sourceImage: disk.image,
+            diskSizeGb: disk.sizeGb,
+        },
+        mode: "READ_WRITE",
+        type: "PERSISTENT",
+    }
+}


### PR DESCRIPTION
Add Ambari example written in Jsonnet, with a "small" variant.

other modifications:
Raise a more user-friendly exception.
Expect the list of resources returned from Jsonnet to be in a field called resources, instead of at the top level
Provides the GCP project name in the jsonnet "environment"
