### PR TITLE
Add Python 3 testing on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,17 @@ branches:
   only:
     - master
 
+before_script:
+  - python --version
+
+script:
+  - make test
+  - if which python3 2> /dev/null ; then
+      make clean;
+      python3 --version;
+      make test PYTHON=python3;
+    fi
+
 # Explanation of `travis_latest`:
 # https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images
 
@@ -96,16 +107,3 @@ jobs:
     - os: osx
 
   fast_finish: true
-
-before_script:
-  - python --version
-  - if [ -f /usr/bin/python3 ]; then
-      python3 --version;
-    fi
-  - pip --version
-  - if [ -f /usr/bin/pip3 ]; then
-      pip3 --version;
-    fi
-
-script:
-  - make test

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ default:
 	$(VERB) $(ECHO) "Valid targets: clean, test."
 
 clean:
-	$(VERB) rm -f src/*.pyc
+	$(VERB) rm -f `find . -name \*\.pyc`
 
 test:
 	$(VERB) make -s -C tests test

--- a/src/config.py
+++ b/src/config.py
@@ -43,7 +43,7 @@ def ProcessConfig(**kwargs):
     }
 
     filename = kwargs['file']
-    for ext, config in ext_to_config.iteritems():
+    for (ext, config) in ext_to_config.items():
         if filename.endswith(ext):
             return config(**kwargs).ExpandFile(filename)
 

--- a/src/config_json.py
+++ b/src/config_json.py
@@ -27,7 +27,7 @@ class ConfigExpander(object):
 
     def __init__(self, **kwargs):
         self.__kwargs = {}
-        for key, value in kwargs.iteritems():
+        for (key, value) in kwargs.items():
             self.__kwargs[key] = value
 
     def ExpandFile(self, file_name):

--- a/src/config_jsonnet.py
+++ b/src/config_jsonnet.py
@@ -37,7 +37,7 @@ class ConfigExpander(object):
 
     def __init__(self, **kwargs):
         self.__kwargs = {}
-        for key, value in kwargs.iteritems():
+        for (key, value) in kwargs.items():
             self.__kwargs[key] = value
 
     def ExpandFile(self, file_name):

--- a/src/config_py.py
+++ b/src/config_py.py
@@ -47,7 +47,7 @@ class ConfigExpander(object):
 
     def __init__(self, **kwargs):
         self.__kwargs = {}
-        for key, value in kwargs.iteritems():
+        for (key, value) in kwargs.items():
             self.__kwargs[key] = value
 
         project = None

--- a/src/gce.py
+++ b/src/gce.py
@@ -78,7 +78,7 @@ class Util(object):
     @classmethod
     def updateResourceWithParams(cls, resource, params):
         resource = bunch.bunchify(resource)
-        for key, val in params.iteritems():
+        for (key, val) in params.items():
             if val is not None:
                 resource[key] = val
 

--- a/src/vm_images.py
+++ b/src/vm_images.py
@@ -40,7 +40,7 @@ if PROJECT_IMAGES is None:
 def ImageShortNameToUrl(image):
     image_url_fmt = 'https://www.googleapis.com/compute/v1/projects/%(project)s/global/images/%(image)s'
 
-    for project, data in PROJECT_IMAGES.iteritems():
+    for (project, data) in PROJECT_IMAGES.items():
         if image in data['images']:
             return image_url_fmt % {
                 'project': project,

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -39,17 +39,17 @@ class ConfigExpanderTest(unittest.TestCase):
         equal = True
         for key in actual:
             if key not in expected:
-                print 'Not found in expected: %s' % key
+                print('Not found in expected: %s' % key)
                 equal = False
 
         for key in expected:
             if key not in actual:
-                print 'Not found in actual: %s' % key
+                print('Not found in actual: %s' % key)
                 equal = False
             elif expected[key] != actual[key]:
-                print ('Unequal for key: %s\n'
+                print(('Unequal for key: %s\n'
                        '       expected: %s\n'
-                       '         actual: %s\n') % (key, expected[key], actual[key])
+                       '         actual: %s\n') % (key, expected[key], actual[key]))
                 equal = False
 
         self.assertTrue(equal, 'Differences found')

--- a/tests/test_scripts.sh
+++ b/tests/test_scripts.sh
@@ -23,9 +23,22 @@ echo "--------------------"
 echo "Running script tests"
 echo "--------------------"
 for test in *_test.*; do
-  echo -n "Testing ${test} ... "
   tempfile="$(mktemp "/tmp/$test.XXXXXX")"
-  env PYTHONPATH="${PYTHONPATH}" "./${test}" > "${tempfile}" 2>&1
+  if [[ $test =~ _test.py ]]; then
+    if [ -n "${PYTHON:-}" ]; then
+      echo -n "Testing ${test} (with ${PYTHON}) ... "
+    else
+      echo -n "Testing ${test} ... "
+    fi
+    # If the $PYTHON env var is set, it should point to the user-preferred
+    # version of the Python interpreter. If it's unset, we will use the default
+    # path to the Python interpreter, as specified at the top of each Python
+    # test file.
+    env PYTHONPATH="${PYTHONPATH}" ${PYTHON:-} "./${test}" > "${tempfile}" 2>&1
+  else
+    echo -n "Testing ${test} ... "
+    "./${test}" > "${tempfile}" 2>&1
+  fi
   if [ $? -eq 0 ]; then
     echo "PASSED"
     rm -f "${tempfile}"

--- a/tests/vm_images_test.py
+++ b/tests/vm_images_test.py
@@ -36,14 +36,14 @@ class ImageShortNameToUrlTest(unittest.TestCase):
         }
 
     def testDirectReferenceImages(self):
-        for project, data in vm_images.PROJECT_IMAGES.iteritems():
+        for (project, data) in vm_images.PROJECT_IMAGES.items():
             for image in data['images']:
                 self.assertEqual(
                     self.projectImageToUrl(project, image),
                     vm_images.ImageShortNameToUrl(image))
 
     def testPseudoImages(self):
-        for project, data in vm_images.PROJECT_IMAGES.iteritems():
+        for (project, data) in vm_images.PROJECT_IMAGES.items():
             if not 'pseudo' in data:
                 continue
             for pseudo in data['pseudo']:

--- a/third_party/bunch/bunch/python3_compat.py
+++ b/third_party/bunch/bunch/python3_compat.py
@@ -1,6 +1,6 @@
-import platform
+import sys
 
-_IS_PYTHON_3 = (platform.version() >= '3')
+_IS_PYTHON_3 = (sys.version[0] >= '3')
 
 identity = lambda x : x
 


### PR DESCRIPTION
Fix Python 3 version detection in bunch

---

Since we always use `#!/usr/bin/python` in our Python scripts, and since
`/usr/bin/python` on all version of macOS is Python 2.7.x, we are not
actually testing with Python3 regardless of the version of our Xcode
installation. This attempt sets an explicit choice to use Python3 for
several of macOS versions, and the test runner script is adjusted to
take into account the env var `$PYTHON`, which, if set, points to the
preferred Python binary to use for running the Python tests.

Also ensured code is now Python 3 compatible:

* replaced `print` statement with `print()` function
* replaced `dict.iteritems()` with `dict.items()`