### PR TITLE
Remove unused Python pip cache as it breaks tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
 
       - name: Update PYTHONPATH
         run: |


### PR DESCRIPTION
https://github.com/mbrukman/cloud-launcher/actions/runs/16582681299/job/46901919689

> Post Set up Python
>
> Post job cleanup.
> Error: Cache folder path is retrieved for pip but doesn't exist on disk:
> /home/runner/.cache/pip. This likely indicates that there are no dependencies
> to cache. Consider removing the cache step if it is not needed.