### PR TITLE
Add file paths to GitHub Actions configs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,11 +14,29 @@
 
 name: "Lint"
 
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
 on:
   push:
     branches: [ main ]
+    paths:
+        # Python files
+      - '**/*.py'
+        # Data files
+      - '**/*.json'
+        # Relevant CI configs
+      - '.github/workflows/lint.yaml' # this file
+
   pull_request:
     branches: [ main ]
+    paths:
+        # Python files
+      - '**/*.py'
+        # Data files
+      - '**/*.json'
+        # Relevant CI configs
+      - '.github/workflows/lint.yaml' # this file
 
 jobs:
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,11 +14,29 @@
 
 name: "Run tests"
 
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
 on:
   push:
     branches: [ main ]
+    paths:
+        # Python files
+      - '**/*.py'
+        # Data files
+      - '**/*.json'
+        # Relevant CI configs
+      - '.github/workflows/tests.yaml' # this file
+
   pull_request:
     branches: [ main ]
+    paths:
+        # Python files
+      - '**/*.py'
+        # Data files
+      - '**/*.json'
+        # Relevant CI configs
+      - '.github/workflows/tests.yaml' # this file
 
 jobs:
 

--- a/.github/workflows/typecheck.yaml
+++ b/.github/workflows/typecheck.yaml
@@ -14,11 +14,29 @@
 
 name: "Typecheck"
 
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
 on:
   push:
     branches: [ main ]
+    paths:
+        # Python files
+      - '**/*.py'
+        # Data files
+      - '**/*.json'
+        # Relevant CI configs
+      - '.github/workflows/typecheck.yaml' # this file
+
   pull_request:
     branches: [ main ]
+    paths:
+        # Python files
+      - '**/*.py'
+        # Data files
+      - '**/*.json'
+        # Relevant CI configs
+      - '.github/workflows/typecheck.yaml' # this file
 
 jobs:
 


### PR DESCRIPTION
This enables running fewer workflows if we modify a single workflow file, for example.