### PR TITLE
Replace /usr/bin/python with env

### DIFF
--- a/console/appengine/compute_api.py
+++ b/console/appengine/compute_api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc.
 #
@@ -72,7 +72,7 @@ class %(class)s(%(baseClass)s):
         return self._%(verb)s(
             obj='%(object)s', method='%(method)s',
             args=%(methodArgs)s)
-""") % {
+""" % {
           'class': className(item),
           'baseClass': BASE_CLASS,
           'verb': item['verb'].lower(),
@@ -80,7 +80,7 @@ class %(class)s(%(baseClass)s):
           'object': item['object'],
           'method': item['method'],
           'methodArgs': methodArgs(item),
-      }
+      })
 
         # Output routes.
         print('routes = [')

--- a/console/appengine/compute_api_base_test.py
+++ b/console/appengine/compute_api_base_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc.
 #


### PR DESCRIPTION
While Linux typically has /usr/bin/python, macOS does not have /usr/bin/python, but it does have /usr/bin/python3 which does not necessarily exist on Linux.

However, both systems have `python` binary in the path in GitHub Actions, so we can use `env` to discover that binary which we should use for these files.

Additionally, fixed syntax error for `print()` and multi-line variable substitution using named placeholders with a `dict` for substitutions.