### PR TITLE
Fix function and var name to use snake_case

### DIFF
--- a/console/appengine/compute_api.py
+++ b/console/appengine/compute_api.py
@@ -27,7 +27,7 @@ import yaml
 BASE_CLASS = 'compute_api_base.ComputeV1Base'
 
 
-def className(item):
+def class_name(item):
     """Returns class name given the item dictionary.
 
     Args:
@@ -41,7 +41,7 @@ def className(item):
     return 'ComputeV1%s%sHandler' % (obj, method)
 
 
-def methodArgs(item):
+def method_args(item):
     """Returns a dictionary formatted as a string given the arguments in item.
 
     Args:
@@ -70,20 +70,20 @@ def main(argv):
         # Output class definitions.
         for item in data:
             print("""\
-class %(class)s(%(baseClass)s):
+class %(class)s(%(base_class)s):
     @decorator.oauth_required
-    def %(verb)s(self, %(verbArgs)s):
+    def %(verb)s(self, %(verb_args)s):
         return self._%(verb)s(
             obj='%(object)s', method='%(method)s',
-            args=%(methodArgs)s)
+            args=%(method_args)s)
 """ % {
-          'class': className(item),
-          'baseClass': BASE_CLASS,
+          'class': class_name(item),
+          'base_class': BASE_CLASS,
           'verb': item['verb'].lower(),
-          'verbArgs': ', '.join(item['args']),
+          'verb_args': ', '.join(item['args']),
           'object': item['object'],
           'method': item['method'],
-          'methodArgs': methodArgs(item),
+          'method_args': method_args(item),
       })
 
         # Output routes.
@@ -92,7 +92,7 @@ class %(class)s(%(baseClass)s):
         for item in data:
             print('    webapp2.Route(')
             print("        '%s'," % item['url'])
-            print('        %s),' % className(item))
+            print('        %s),' % class_name(item))
 
         print(']')
 

--- a/console/appengine/compute_api_base.py
+++ b/console/appengine/compute_api_base.py
@@ -43,7 +43,7 @@ USER_AGENT = '%s/%s (github.com/mbrukman/cloud-launcher/tree/master/console)' % 
 MEMCACHE_TIMEOUT = 30
 
 
-def Http():
+def create_http():
     """Returns an instance of `httplib2.Http` with User-agent set."""
     http = httplib2.Http(memcache)
     return apiclient_http.set_user_agent(http, USER_AGENT)
@@ -61,7 +61,7 @@ class ComputeV1Base(webapp2.RequestHandler):
         if memcache_value:
             output = memcache_value
         else:
-            http = decorator.credentials.authorize(Http())
+            http = decorator.credentials.authorize(create_http())
             service = apiclient_discovery.build('compute', 'v1', http=http)
             try:
                 response = service.__dict__[obj]().__dict__[
@@ -87,7 +87,7 @@ class ComputeV1Base(webapp2.RequestHandler):
     def _post(self, obj, method, args):
         status_int = 200
         response = {}
-        http = decorator.credentials.authorize(Http())
+        http = decorator.credentials.authorize(create_http())
         service = apiclient_discovery.build('compute', 'v1', http=http)
         try:
             response = service.__dict__[obj]().__dict__[

--- a/console/appengine/compute_api_base_test.py
+++ b/console/appengine/compute_api_base_test.py
@@ -51,7 +51,7 @@ import httpretty
 
 class RequestHandlersTest(unittest.TestCase):
     def setUp(self):
-        super(RequestHandlersTest, self).setUp()
+        super().setUp()
         # For more info, see:
         # https://cloud.google.com/appengine/docs/python/tools/localunittesting
         self.testbed = testbed.Testbed()
@@ -72,15 +72,15 @@ class RequestHandlersTest(unittest.TestCase):
         httpretty.reset()
         self.testbed.deactivate()
 
-    def testUserAgent(self):
-        mockContent = 'This is some content'
+    def test_user_agent(self):
+        mock_content = 'This is some content'
         httpretty.register_uri(httpretty.GET, 'http://localhost:9000/',
-                               body=mockContent)
+                               body=mock_content)
         http = self.compute_api_base.Http()
-        (resp_headers, content) = http.request("http://localhost:9000", "GET")
+        _, content = http.request("http://localhost:9000", "GET")
         self.assertEqual(httpretty.last_request().headers['user-agent'],
                          self.compute_api_base.USER_AGENT)
-        self.assertEqual(content, mockContent)
+        self.assertEqual(content, mock_content)
 
 
 if __name__ == '__main__':

--- a/src/common.py
+++ b/src/common.py
@@ -22,61 +22,61 @@ import os
 import sys
 
 
-def ProjectUrl(project):
+def project_url(project):
     return 'https://www.googleapis.com/compute/%(api_version)s/projects/%(project)s' % {
         'api_version': 'v1',
         'project': project,
     }
 
 
-def ProjectZoneUrl(project, zone):
+def project_zone_url(project, zone):
     return '%(project_url)s/zones/%(zone)s' % {
-        'project_url': ProjectUrl(project),
+        'project_url': project_url(project),
         'zone': zone,
     }
 
 
-def ProjectGlobalUrl(project):
+def project_global_url(project):
     return '%(project_url)s/global' % {
-        'project_url': ProjectUrl(project),
+        'project_url': project_url(project),
     }
 
 
-def DiskTypeToUrl(project, zone, diskType):
+def disk_type_to_url(project, zone, diskType):
     assert diskType in ('pd-standard', 'pd-ssd')
     return '%(zone_url)s/diskTypes/%(diskType)s' % {
-        'zone_url': ProjectZoneUrl(project, zone),
+        'zone_url': project_zone_url(project, zone),
         'diskType': diskType,
     }
 
 
-def ImageToUrl(project, image):
+def image_to_url(project, image):
     return '%(project_url)s/images/%(image)s' % {
-        'project_url': ProjectGlobalUrl(project),
+        'project_url': project_global_url(project),
         'image': image,
     }
 
 
-def MachineTypeToUrl(project, zone, machineType):
+def machine_type_to_url(project, zone, machineType):
     return '%(zone_url)s/machineTypes/%(machineType)s' % {
-        'zone_url': ProjectZoneUrl(project, zone),
+        'zone_url': project_zone_url(project, zone),
         'machineType': machineType,
     }
 
 
-def NetworkToUrl(project, network):
+def network_to_url(project, network):
     return '%(project_url)s/networks/%(network)s' % {
-        'project_url': ProjectGlobalUrl(project),
+        'project_url': project_global_url(project),
         'network': network,
     }
 
 
-def IsUrl(string):
+def is_url(string):
     return (string.startswith('http://') or
             string.startswith('https://'))
 
 
-def ReadReferencedFileToString(base_file, referenced_file):
+def read_referenced_file_to_string(base_file, referenced_file):
     """Given a string '%file:<path>'; returns the contents of file at <path>.
 
     Args:

--- a/src/config_json.py
+++ b/src/config_json.py
@@ -23,7 +23,7 @@ import os
 import sys
 
 
-class ConfigExpander(object):
+class ConfigExpander:
 
     def __init__(self, **kwargs):
         self.__kwargs = {}

--- a/src/config_jsonnet.py
+++ b/src/config_jsonnet.py
@@ -32,7 +32,7 @@ class JsonnetNotFoundError(Error):
     pass
 
 
-class ConfigExpander(object):
+class ConfigExpander:
 
     def __init__(self, **kwargs):
         self.__kwargs = {}

--- a/src/gce.py
+++ b/src/gce.py
@@ -28,9 +28,9 @@ import vm_images
 true = True
 
 
-class GCE(object):
+class GCE:
 
-    class Settings(object):
+    class Settings:
         project = None
         zone = None
 
@@ -73,7 +73,7 @@ class GCE(object):
             return cls.default.zone
 
 
-class Util(object):
+class Util:
 
     @classmethod
     def updateResourceWithParams(cls, resource, params):
@@ -85,7 +85,7 @@ class Util(object):
         return resource
 
 
-class Image(object):
+class Image:
 
     @classmethod
     def resolve(cls, image, project=None):
@@ -106,10 +106,10 @@ class Image(object):
         try:
             return vm_images.ImageShortNameToUrl(image)
         except:
-            return common.ImageToUrl(project, image)
+            return common.image_to_url(project, image)
 
 
-class Disk(object):
+class Disk:
 
     def __init__(self):
         assert False, 'Do not create a Disk via instance ctor; use static factory method instead'
@@ -126,8 +126,8 @@ class Disk(object):
         }
 
         # Ensure that the user specified this parameter correctly.
-        if (diskType is not None) and (not common.IsUrl(diskType)):
-            diskType = common.DiskTypeToUrl(
+        if (diskType is not None) and (not common.is_url(diskType)):
+            diskType = common.disk_type_to_url(
                 GCE.project(), GCE.zone(), diskType)
 
         params = {
@@ -174,12 +174,12 @@ class Disk(object):
         return cls.attachedDisk(**kwargs)
 
 
-class Network(object):
+class Network:
 
     @classmethod
     def externalNat(cls, name=None):
         resource = {
-            'network': common.NetworkToUrl(GCE.project(), 'default'),
+            'network': common.network_to_url(GCE.project(), 'default'),
             'accessConfigs': [
                 {
                     'type': 'ONE_TO_ONE_NAT',
@@ -188,8 +188,8 @@ class Network(object):
             ],
         }
 
-        if name is not None and not common.IsUrl(name):
-            name = common.NetworkToUrl(GCE.project(), name)
+        if name is not None and not common.is_url(name):
+            name = common.network_to_url(GCE.project(), name)
 
         params = {
             'network': name,
@@ -209,7 +209,7 @@ class Network(object):
         return Util.updateResourceWithParams(resource, params)
 
 
-class Metadata(object):
+class Metadata:
 
     @classmethod
     def create(cls, items=None):
@@ -242,14 +242,14 @@ class Metadata(object):
                 previous = filename
                 break
 
-        return common.ReadReferencedFileToString(previous, '%%file:%s' % path)
+        return common.read_referenced_file_to_string(previous, '%%file:%s' % path)
 
     @classmethod
     def startupScript(cls, path):
         return Metadata.item('startup-script', Metadata.fileToString(path))
 
 
-class Compute(object):
+class Compute:
 
     @classmethod
     def instance(
@@ -279,8 +279,8 @@ class Compute(object):
             ],
         }
 
-        if machineType is not None and not common.IsUrl(machineType):
-            machineType = common.MachineTypeToUrl(
+        if machineType is not None and not common.is_url(machineType):
+            machineType = common.machine_type_to_url(
                 GCE.project(), GCE.zone(), machineType)
 
         params = {


### PR DESCRIPTION
Replace camelCase maing with snake_case naming to fix lint warnings.

Also minor other fixes:

* remove unneeded `object` inheritance (noop in Python 3)
* use parameter-less `super()` to call methods on parent class
* use lower_case_snake for local vars, even if they're const