### PR TITLE
Replace Python 2 `imp` with Python 3 `importlib`

### DIFF
--- a/tests/generate_test_outputs.sh
+++ b/tests/generate_test_outputs.sh
@@ -19,12 +19,13 @@
 declare -i EXIT_CODE=0
 declare -r SOURCE_PATH="../src"
 declare -r PYTHONPATH="${SOURCE_PATH}:../third_party/bunch"
+declare -r PYTHON="${PYTHON:-python}"
 
 for in_py in testdata/*_in.py; do
   out_json="$(echo "${in_py}" | sed 's/_in.py/_out.json/')"
   out_json_base="$(basename "${out_json}")"
   tempfile="$(mktemp "/tmp/${out_json_base}.XXXXXX")"
-  env PYTHONPATH="${PYTHONPATH}" "${SOURCE_PATH}/config_py.py" "${in_py}" > "${tempfile}" 2>&1
+  env PYTHONPATH="${PYTHONPATH}" "${PYTHON}" "${SOURCE_PATH}/config_py.py" "${in_py}" > "${tempfile}" 2>&1
   if [ $? -eq 0 ]; then
     mv "${tempfile}" "${out_json}"
   else

--- a/tests/test_py_to_json.sh
+++ b/tests/test_py_to_json.sh
@@ -17,6 +17,7 @@
 # Runs all Python -> JSON tests.
 
 declare -i STATUS=0
+declare -r PYTHON="${PYTHON:-python}"
 
 echo
 echo "------------------------"
@@ -28,7 +29,7 @@ for in_py in testdata/*_in.py; do
   out_json_base="$(basename "${out_json}")"
   echo -n "Testing ${in_py} -> ${out_json} ... "
   tempfile="$(mktemp "/tmp/${out_json_base}.XXXXXX")"
-  env PYTHONPATH="${PYTHONPATH}" "${SOURCE_PATH}/config_py.py" "${in_py}" > "${tempfile}" 2>&1
+  env PYTHONPATH="${PYTHONPATH}" "${PYTHON}" "${SOURCE_PATH}/config_py.py" "${in_py}" > "${tempfile}" 2>&1
 
   if [ $? -ne 0 ]; then
     STATUS=1

--- a/tests/test_scripts.sh
+++ b/tests/test_scripts.sh
@@ -17,6 +17,7 @@
 # Runs all *_test.* scripts.
 
 declare -i STATUS=0
+declare -r PYTHON="${PYTHON:-python}"
 
 echo
 echo "--------------------"
@@ -24,19 +25,10 @@ echo "Running script tests"
 echo "--------------------"
 for test in *_test.*; do
   tempfile="$(mktemp "/tmp/$test.XXXXXX")"
+  echo -n "Testing ${test} ... "
   if [[ $test =~ _test.py ]]; then
-    if [ -n "${PYTHON:-}" ]; then
-      echo -n "Testing ${test} (with ${PYTHON}) ... "
-    else
-      echo -n "Testing ${test} ... "
-    fi
-    # If the $PYTHON env var is set, it should point to the user-preferred
-    # version of the Python interpreter. If it's unset, we will use the default
-    # path to the Python interpreter, as specified at the top of each Python
-    # test file.
-    env PYTHONPATH="${PYTHONPATH}" ${PYTHON:-} "./${test}" > "${tempfile}" 2>&1
+    env PYTHONPATH="${PYTHONPATH}" "${PYTHON}" "./${test}" > "${tempfile}" 2>&1
   else
-    echo -n "Testing ${test} ... "
     "./${test}" > "${tempfile}" 2>&1
   fi
   if [ $? -eq 0 ]; then


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.12.html#imp

Also added ability to specify Python interpreter for running Python tests via shell scripts, with the default being `python` which can be found in `$PATH` rather than assuming that it's always at `/usr/bin/python` which is not the case for macOS which has `/usr/bin/python3`, for example, but on GitHub Actions, there exists a `python` binary somewhere in the `$PATH`.