### PR TITLE
Make launcher test failures break the workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,7 +64,6 @@ jobs:
       - name: Run tests
         run: |
           make test VERBOSE=1
-        continue-on-error: true
 
   console:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Remove `continue-on-error: true` now that they're all passing:

* [Launcher: py-3.8 on ubuntu-24.04][1]
* [Launcher: py-3.9 on ubuntu-24.04][2]
* [Launcher: py-3.8 on macos-14][3]
* [Launcher: py-3.9 on macos-14][4]

[1]: https://github.com/mbrukman/cloud-launcher/actions/runs/16611713037/job/46995938630?pr=33
[2]: https://github.com/mbrukman/cloud-launcher/actions/runs/16611713037/job/46995938626?pr=33
[3]: https://github.com/mbrukman/cloud-launcher/actions/runs/16611713037/job/46995938629?pr=33
[4]: https://github.com/mbrukman/cloud-launcher/actions/runs/16611713037/job/46995938655?pr=33